### PR TITLE
fix: emit terminal Add animation for add-only sections

### DIFF
--- a/src/manim_widget/renderer.py
+++ b/src/manim_widget/renderer.py
@@ -309,6 +309,48 @@ class CaptureRenderer:
             )
         self._staged_adds = {}
 
+    def emit_final_add_animations(self, scene: Scene) -> None:
+        """Emit a terminal animate command with Add descriptors if needed.
+
+        This covers sections that only call ``self.add(...)`` and never call
+        ``play(...)``. In that case we still need an animate batch so the JS
+        player can apply the semantic Add operation.
+        """
+        current = self._current
+        if current is None:
+            return
+
+        def _is_supported(mob: Mobject) -> bool:
+            if isinstance(mob, VMobject | ValueTracker | AbstractImageMobject):
+                return True
+            return bool(hasattr(mob, "submobjects") and mob.submobjects)
+
+        # Only emit a terminal Add batch for sections with no playback commands.
+        # If section already has animate/updater entries, Add injection should
+        # happen during play-path handling instead.
+        if any(cmd.get("cmd") in {"animate", "updater"} for cmd in current.commands):
+            return
+
+        add_animations: list[dict[str, str]] = []
+        for mob in scene.mobjects:
+            if not _is_supported(mob):
+                continue
+            if not self.is_active(mob):
+                continue
+            if self._introduced_by_animation.get(id(mob), False):
+                continue
+            add_animations.append({"kind": "Add", "id": self.short_id(mob)})
+            self._introduced_by_animation[id(mob)] = True
+
+        if add_animations:
+            current.commands.append(
+                {
+                    "cmd": "animate",
+                    "duration": 0,
+                    "animations": add_animations,
+                }
+            )
+
     def stage_add(self, mob: Mobject) -> None:
         """Stage an add command until play()/section-finalization flushes it."""
         self._staged_adds[self.short_id(mob)] = mob

--- a/src/manim_widget/widget.py
+++ b/src/manim_widget/widget.py
@@ -66,6 +66,8 @@ class ManimWidget(anywidget.AnyWidget, ThreeDScene):
         # Capture final camera state if changed (for last section)
         # Flush any remaining staged adds for final section with no play().
         self._renderer.flush_staged_adds()
+        # If section only had add() calls and no play(), still emit semantic Add.
+        self._renderer.emit_final_add_animations(self)
 
         final_cam = self._get_camera_state()
         last_section = (
@@ -189,6 +191,9 @@ class ManimWidget(anywidget.AnyWidget, ThreeDScene):
         del section_type, skip_animations
         # Finalize staged adds into the outgoing section before section switch.
         self._renderer.flush_staged_adds()
+        # If outgoing section had only add() calls, emit terminal Add animate batch.
+        self._renderer.emit_final_add_animations(self)
+
         self._renderer.open_section(name)
         self._snapshots[name] = self._snapshot_from_registry()
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -410,6 +410,63 @@ def test_create_without_explicit_add_does_not_emit_add_animation():
     assert any(a["kind"] == "Create" and a["id"] == "0" for a in anim_cmd["animations"])
 
 
+def test_mathtex_add_only_emits_add_animation():
+    from manim_widget import patch_tex
+    import manim
+
+    original_math_tex = manim.MathTex
+    original_tex = manim.Tex
+
+    patch_tex()
+    try:
+        from manim import MathTex, WHITE
+
+        class MathTexAddOnlyScene(ManimWidget):
+            def construct(self):
+                tex = MathTex(r"{0}", fill_color=WHITE)
+                self.add(tex)
+
+        scene = MathTexAddOnlyScene(fps=10)
+        section = scene.scene_data["sections"][0]
+        anim_cmd = next(cmd for cmd in section["construct"] if cmd["cmd"] == "animate")
+
+        assert any(
+            a["kind"] == "Add" and a["id"] == "0" for a in anim_cmd["animations"]
+        )
+    finally:
+        manim.MathTex = original_math_tex
+        manim.Tex = original_tex
+
+
+def test_mathtex_add_only_then_empty_section_emits_add_in_first_section():
+    from manim_widget import patch_tex
+    import manim
+
+    original_math_tex = manim.MathTex
+    original_tex = manim.Tex
+
+    patch_tex()
+    try:
+        from manim import MathTex, WHITE
+
+        class MathTexAddThenEmptySectionScene(ManimWidget):
+            def construct(self):
+                tex = MathTex(r"{0}", fill_color=WHITE)
+                self.add(tex)
+                self.next_section("empty")
+
+        scene = MathTexAddThenEmptySectionScene(fps=10)
+        first = scene.scene_data["sections"][0]
+        anim_cmd = next(cmd for cmd in first["construct"] if cmd["cmd"] == "animate")
+
+        assert any(
+            a["kind"] == "Add" and a["id"] == "0" for a in anim_cmd["animations"]
+        )
+    finally:
+        manim.MathTex = original_math_tex
+        manim.Tex = original_tex
+
+
 def test_image_mobject_serializes_source_and_pixels():
     pixels = np.array(
         [


### PR DESCRIPTION
Ensure add-only sections serialize an animate/Add batch at section end, including when transitioning to a new empty section.

Add regression tests for MathTex add-only and add-only-then-empty-section flows.

## Checklist

- [x] Ruff passes: `uvx ruff check . && uvx ruff format --check .`
- [x] Python tests pass: `uv run pytest -q tests/test_widget.py`
- [x] JS integration tests pass: `uv run pytest -q tests/test_js_integration.py`
- [x] If JS source changed: bundle rebuilt (`cd js && bun run build`)
- [x] If the emitted `scene_data` JSON changed shape: `spec.json` reflects the new shape and was updated before the code

## Testing notes

added 2 new tests
