### PR TITLE
fix: capture camera on section boundary

### DIFF
--- a/src/manim_widget/widget.py
+++ b/src/manim_widget/widget.py
@@ -94,31 +94,11 @@ class ManimWidget(anywidget.AnyWidget, ThreeDScene):
         attr_name: str,
         default: float,
     ) -> float:
-        cam = self.camera
-        getter = getattr(cam, getter_name, None)
-        method_val = float(getter()) if callable(getter) else default
-
-        raw_attr = getattr(cam, attr_name, method_val)
-        attr_val = float(raw_attr) if isinstance(raw_attr, int | float) else method_val
-
-        if abs(attr_val - method_val) <= 1e-12:
-            return method_val
-
-        # If method/tracker and raw attr disagree, prefer whichever changed more
-        # from the previous serialized state. This captures direct assignments like
-        # `self.camera.theta = 0.2` while still preserving animated tracker values.
-        if self._last_camera_state is not None and key in self._last_camera_state:
-            prev = float(self._last_camera_state[key])
-            if abs(attr_val - prev) > abs(method_val - prev) + 1e-12:
-                return attr_val
-            return method_val
-
-        # First capture fallback: if method value sits at canonical default while
-        # attr deviates, treat attr as an explicit override.
-        if abs(method_val - default) <= 1e-12 and abs(attr_val - default) > 1e-12:
-            return attr_val
-
-        return method_val
+        del key, getter_name, default
+        raw_attr = getattr(self.camera, attr_name, None)
+        if isinstance(raw_attr, int | float):
+            return float(raw_attr)
+        return 0.0
 
     def _resolve_camera_scalar(
         self,
@@ -127,19 +107,11 @@ class ManimWidget(anywidget.AnyWidget, ThreeDScene):
         canonical: float,
         attr_name: str,
     ) -> float:
-        raw_attr = getattr(self.camera, attr_name, canonical)
-        attr_val = float(raw_attr) if isinstance(raw_attr, int | float) else canonical
-
-        if abs(attr_val - canonical) <= 1e-12:
-            return canonical
-
-        if self._last_camera_state is not None and key in self._last_camera_state:
-            prev = float(self._last_camera_state[key])
-            if abs(attr_val - prev) > abs(canonical - prev) + 1e-12:
-                return attr_val
-            return canonical
-
-        return attr_val
+        del key
+        raw_attr = getattr(self.camera, attr_name, None)
+        if isinstance(raw_attr, int | float):
+            return float(raw_attr)
+        return canonical
 
     def _get_camera_state(self) -> dict[str, float]:
         """Capture current 3D camera state including computed FOV."""
@@ -196,14 +168,18 @@ class ManimWidget(anywidget.AnyWidget, ThreeDScene):
         # If outgoing section had only add() calls, emit terminal Add animate batch.
         self._renderer.emit_final_add_animations(self)
 
+        # Capture camera for outgoing section before section switch
+        current_section = self._renderer.sections[-1].name
+        cam_state = self._get_camera_state()
+        changed = self._camera_changed(cam_state)
+        if changed:
+            self._cameras[current_section] = cam_state
+            self._last_camera_state = cam_state
+
         self._renderer.open_section(name)
         self._snapshots[name] = self._snapshot_from_registry()
-
-        # Capture camera only if changed
-        cam_state = self._get_camera_state()
-        if self._camera_changed(cam_state):
+        if changed:
             self._cameras[name] = cam_state
-            self._last_camera_state = cam_state
 
     def _snapshot_from_registry(self) -> dict[str, int]:
         """Build snapshot as mob_id -> state_ref mapping.

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -869,3 +869,35 @@ def test_arrow_serializes_with_arrow_kind():
     assert "points" in arrow_state
     assert "children" in arrow_state
     assert len(arrow_state["children"]) == 1  # One tip child
+
+
+def test_camera_set_before_next_section_appears_in_first_and_second_sections():
+    """Test that camera parameters set before next_section() appear in both outgoing and new section entry."""
+
+    class CameraSetupScene(ManimWidget):
+        def construct(self):
+            # Manually set camera parameters before any sections
+            self.camera.theta = 0.5
+            self.camera.phi = 0.3
+            self.camera.distance = 10.0
+            self.next_section("after_camera_setup")
+
+    scene = CameraSetupScene(fps=10)
+    data = scene.scene_data
+
+    first_section = data["sections"][0]
+    second_section = data["sections"][1]
+
+    assert first_section["name"] == "initial"
+    assert second_section["name"] == "after_camera_setup"
+
+    first_camera = first_section["camera"]
+    second_camera = second_section["camera"]
+
+    assert abs(first_camera["theta"] - 0.5) < 1e-9
+    assert abs(first_camera["phi"] - 0.3) < 1e-9
+    assert abs(first_camera["distance"] - 10.0) < 1e-9
+
+    assert abs(second_camera["theta"] - 0.5) < 1e-9
+    assert abs(second_camera["phi"] - 0.3) < 1e-9
+    assert abs(second_camera["distance"] - 10.0) < 1e-9


### PR DESCRIPTION
Record camera updates on the outgoing section before next_section(), and mirror that state to the new section entry when the camera changed. Also add regression coverage for camera values across the boundary.

## Checklist

- [x] Ruff passes: `uvx ruff check . && uvx ruff format --check .`
- [x] Python tests pass: `uv run pytest -q tests/test_widget.py`
- [x] JS integration tests pass: `uv run pytest -q tests/test_js_integration.py`
- [x] If JS source changed: bundle rebuilt (`cd js && bun run build`)

## Testing notes

updated an old test with broken behaviour
