### PR TITLE
feat(tests): faster JS tests  + example test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-
       - name: Install system dependencies (Linux)
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: python3-opengl libpango1.0-dev xvfb freeglut3-dev
           version: 1.0
-
 
       - name: Install Python deps
         run: uv sync
@@ -81,3 +79,35 @@ jobs:
       - name: JS integration tests
         timeout-minutes: 5
         run: uv run pytest -q tests/test_js_integration.py
+
+  examples:
+    name: Example tests
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install system dependencies (Linux)
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: python3-opengl libpango1.0-dev xvfb freeglut3-dev
+          version: 1.0
+
+      - name: Install Python deps
+        run: uv sync
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install JS deps
+        working-directory: js
+        run: bun install
+
+      - name: Example tests
+        timeout-minutes: 5
+        run: uv run pytest -q tests/test_examples.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Families: `SimpleAnimation`, `TransformAnimation` (`Transform`, `MoveToTarget`),
 - Point arrays that are not `3n+1` will raise a JS-side playback error by design.
 - `_applyState` must apply points based on capability (`setPoints3D`) rather than `state.kind === "VMobject"`. Arrow/VGroup restore creates a body VMobject from VGroup state points; kind-gating drops body points and renders only tips.
 - Headless JS tests (`happy-dom`) can hang if image loading promises never resolve. Keep image-finalization logic non-blocking (timeouts/fallbacks) in `player.js`.
-- Bun/minified bundles can mangle `constructor.name` (e.g., `VGroup`→`e`). CLI integration tests should run Bun with `--conditions source` to keep deterministic end-state kind detection in `js/src/test_cli.js`.
+- `JSRunner` pre-builds `test_cli.js` into `js/node_modules/.cache/manim-widget-test/` once per session (typia baked in). Set `MANIM_WIDGET_JS_DEBUG=1` to skip the bundle and run against TypeScript source for readable stack traces.
 - Renderer command emission should prefer behavior/animation semantics over concrete class checks. Class-targeting can miss valid intro-animation mobjects (e.g., non-VMobject types).
 - Player ordering for textured/async mobjects matters: apply serialized geometry/state mutations before `scene.add(...)`. Mutating after add may only change logical state (`bbox`, `scaleVector`) without immediate visible sync in `manim-web` async render paths (e.g., `MathTexImage`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ uv run pytest -q tests/test_widget.py
 # Slow (~1 min) — run before opening a PR
 uv run pytest -q tests/test_js_integration.py
 
-# Manual JS smoke test (use --conditions source to keep readable class names)
-cd js && bun run cli --conditions source < ../spec.json
+# Manual JS smoke test (add MANIM_WIDGET_JS_DEBUG=1 for source stack traces)
+python tests/js_runner.py --json < spec.json
 ```
 
 ---

--- a/examples/arrow.py
+++ b/examples/arrow.py
@@ -103,5 +103,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(ArrowDance).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/arrow_mre.py
+++ b/examples/arrow_mre.py
@@ -34,5 +34,18 @@ def _():
     return
 
 
+def test(runner):
+    scene = ArrowMRE()
+    # Arrow must be serialized as a VGroup (shaft + tip), not a flat VMobject.
+    # Animating a submobject directly (arrow.submobjects[-1].animate) is a known
+    # JS limitation, so we check the serialization structure in Python.
+    states = scene.scene_data["states"]
+    vgroups = [s for s in states if s.get("kind") == "VGroup"]
+    assert vgroups, "Arrow should be serialized as a VGroup"
+    assert any(len(s["children"]) == 2 for s in vgroups), (
+        "Arrow VGroup should have 2 children (shaft + tip)"
+    )
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/boolean_operations.py
+++ b/examples/boolean_operations.py
@@ -75,5 +75,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(BooleanOperations).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/brace_annotation.py
+++ b/examples/brace_annotation.py
@@ -30,5 +30,11 @@ def _():
     return
 
 
+def test(runner):
+    import pytest
+
+    pytest.skip("requires LaTeX")
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/cyclic_replace_demo.py
+++ b/examples/cyclic_replace_demo.py
@@ -25,5 +25,11 @@ def _():
     return
 
 
+def test(runner):
+    r = runner.check(CyclicReplaceDemo)
+    r.assert_ok()
+    assert len(r.scene_ids(0)) == 3
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/image_gradient.py
+++ b/examples/image_gradient.py
@@ -41,5 +41,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(ImageGradientDemo).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/latex_scale.py
+++ b/examples/latex_scale.py
@@ -39,5 +39,11 @@ def _():
     return
 
 
+def test(runner):
+    import pytest
+
+    pytest.skip("requires LaTeX")
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/logo.py
+++ b/examples/logo.py
@@ -51,5 +51,11 @@ def _():
     return
 
 
+def test(runner):
+    import pytest
+
+    pytest.skip("requires LaTeX")
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/mathtex_add_only.py
+++ b/examples/mathtex_add_only.py
@@ -7,3 +7,9 @@ class MathTexAddOnly(ManimWidget):
     def construct(self):
         tex = MathTex("x=1")
         self.add(tex)
+
+
+def test(runner):
+    import pytest
+
+    pytest.skip("requires LaTeX")

--- a/examples/point_moving_on_shapes.py
+++ b/examples/point_moving_on_shapes.py
@@ -44,5 +44,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(PointMovingOnShapes).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/point_with_trace.py
+++ b/examples/point_with_trace.py
@@ -25,6 +25,24 @@ class PointWithTrace(ManimWidget):
         self.play(Rotating(dot, angle=3.14, about_point=RIGHT, run_time=2))
 
 
+def test(runner):
+    scene = PointWithTrace(fps=5)
+    r = runner.check_data(scene.scene_data)
+    r.assert_ok()
+    section = scene.scene_data["sections"][0]
+    frame_ids = {
+        mob_id
+        for cmd in section["construct"]
+        if cmd["cmd"] == "updater"
+        for frame in cmd["frames"]
+        for mob_id in frame
+    }
+    scene_ids = set(r.scene_ids(0))
+    assert frame_ids <= scene_ids, (
+        f"updater frame IDs not in scene: {frame_ids - scene_ids}"
+    )
+
+
 @app.cell
 def _():
     PointWithTrace()

--- a/examples/polygon_on_axes.py
+++ b/examples/polygon_on_axes.py
@@ -85,5 +85,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(PolygonOnAxes).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/rotate_3d.py
+++ b/examples/rotate_3d.py
@@ -31,5 +31,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(Rotate3D).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/square_to_circle.py
+++ b/examples/square_to_circle.py
@@ -27,5 +27,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(SquareToCircle).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/swap_demo.py
+++ b/examples/swap_demo.py
@@ -26,5 +26,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(SwapDemo).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/sync_slider.py
+++ b/examples/sync_slider.py
@@ -64,5 +64,9 @@ def _(widget, x_slider, y_slider):
     return
 
 
+def test(runner):
+    runner.check(SyncDemo).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/tex_example.py
+++ b/examples/tex_example.py
@@ -33,5 +33,11 @@ def _():
     return
 
 
+def test(runner):
+    import pytest
+
+    pytest.skip("requires LaTeX")
+
+
 if __name__ == "__main__":
     app.run()

--- a/examples/zy_cnn_parallelepipeds.py
+++ b/examples/zy_cnn_parallelepipeds.py
@@ -128,5 +128,9 @@ def _():
     return
 
 
+def test(runner):
+    runner.check(ZYImageCNN).assert_ok()
+
+
 if __name__ == "__main__":
     app.run()

--- a/js/build-test.ts
+++ b/js/build-test.ts
@@ -1,0 +1,17 @@
+import UnpluginTypia from "@typia/unplugin/bun";
+
+const result = await Bun.build({
+  entrypoints: ["src/test_cli.js"],
+  outdir: "node_modules/.cache/manim-widget-test",
+  naming: "[name].js",
+  format: "esm",
+  target: "bun",
+  plugins: [UnpluginTypia({ cache: true, log: false })],
+});
+
+if (!result.success) {
+  for (const log of result.logs) {
+    console.error(log);
+  }
+  process.exit(1);
+}

--- a/js/build-test.ts
+++ b/js/build-test.ts
@@ -6,6 +6,8 @@ const result = await Bun.build({
   naming: "[name].js",
   format: "esm",
   target: "bun",
+  conditions: ["source"],
+  external: ["opentype.js"],
   plugins: [UnpluginTypia({ cache: true, log: false })],
 });
 

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -8,6 +8,7 @@
         "katex": "^0.16.22",
         "manim-web": "file:../manim-web",
         "mathjax-full": "^3.2.2",
+        "opentype.js": "^2.0.0",
         "three": "^0.184.0",
       },
       "devDependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -11,6 +11,7 @@
     "katex": "^0.16.22",
     "manim-web": "file:../manim-web",
     "mathjax-full": "^3.2.2",
+    "opentype.js": "^2.0.0",
     "three": "^0.184.0"
   },
   "devDependencies": {

--- a/js/src/test_cli.js
+++ b/js/src/test_cli.js
@@ -82,12 +82,11 @@ function serializeRuntimeState(registry) {
       return seen.get(mob);
     }
 
-    const ctorName = mob.constructor?.name;
     const opacity = typeof mob.opacity === "number" ? mob.opacity : 1;
     const zIndex = typeof mob.zIndex === "number" ? mob.zIndex : undefined;
 
     let state;
-    if (ctorName === "VGroup" || ctorName === "Arrow") {
+    if (mob instanceof VGroup) {
       const children = Array.isArray(mob.submobjects)
         ? mob.submobjects.map(serializeMobject).filter((ref) => ref !== null)
         : [];
@@ -100,6 +99,7 @@ function serializeRuntimeState(registry) {
         state.z_index = zIndex;
       }
     } else {
+      const ctorName = mob.constructor?.name;
       const kind = VMOBJECT_KINDS.has(ctorName) ? ctorName : "VMobject";
       const points = typeof mob.getPoints === "function" ? normalizePoints(mob.getPoints()) : [];
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,15 @@
+import os
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
+
+
+@pytest.fixture(scope="session")
+def runner():
+    from js_runner import JSRunner
+
+    debug = os.environ.get("MANIM_WIDGET_JS_DEBUG") == "1"
+    return JSRunner(debug=debug)

--- a/tests/js_runner.py
+++ b/tests/js_runner.py
@@ -4,8 +4,9 @@ Requires a manim-widget source checkout (js/ directory) and bun on PATH.
 
 API usage::
 
-    from js_runner import check, check_data
-    result = check(MyScene)
+    from js_runner import JSRunner
+    runner = JSRunner()          # bundles test_cli.js once
+    result = runner.check(MyScene)
     result.assert_ok()
     print(result.errors)
 
@@ -25,14 +26,18 @@ CLI usage::
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 _JS_ROOT = Path(__file__).parent.parent / "js"
+_BUILD_TEST = _JS_ROOT / "build-test.ts"
+_BUNDLE = _JS_ROOT / "node_modules" / ".cache" / "manim-widget-test" / "test_cli.js"
 _CLI = _JS_ROOT / "src" / "test_cli.js"
 _PRELOAD = _JS_ROOT / "src" / "preload-typia.ts"
 
@@ -95,70 +100,113 @@ class JSResult:
         return self.section_ids[section].get("scene_ids", [])
 
 
-def check_data(scene_data: str | dict[str, Any]) -> JSResult:
-    """Validate pre-serialized scene data through the JS headless runner.
+class JSRunner:
+    """Headless JS runner for validating manim-widget scenes against the JS player.
 
-    Args:
-        scene_data: Scene dict (or pre-serialized JSON string).
+    Two modes:
 
-    Returns:
-        JSResult with errors, warnings, section_ids, and section_end_states.
+    **Fast mode** (default, ``debug=False``):
+        Compiles ``js/src/test_cli.js`` + typia into a single bundle once on
+        construction (``js/node_modules/.cache/manim-widget-test/test_cli.js``).
+        Each ``check_data`` call pays only plain ``bun run`` startup (~0.2 s).
+        Use this for CI and normal test runs.
+
+    **Debug mode** (``debug=True``):
+        Skips compilation entirely.  Each call runs
+        ``bun run --preload src/preload-typia.ts --conditions source src/test_cli.js``
+        directly against the TypeScript source, so stack traces include original
+        file names and line numbers.  ~5 s per call — use only when diagnosing a
+        JS-side failure.
+
+    Pytest fixture::
+
+        # conftest.py or top of test file
+        @pytest.fixture(scope="session")
+        def runner():
+            debug = os.environ.get("MANIM_WIDGET_JS_DEBUG") == "1"
+            return JSRunner(debug=debug)
+
+    Then run with ``MANIM_WIDGET_JS_DEBUG=1 uv run pytest ...`` to get source
+    stack traces on a failing test.
     """
-    import tempfile
-    import os
 
-    _check_env()
-    scene_json = json.dumps(scene_data) if isinstance(scene_data, dict) else scene_data
+    def __init__(self, *, debug: bool = False) -> None:
+        _check_env()
+        self._debug = debug
+        if not debug:
+            self._build()
 
-    # Write input to a temp file to avoid pipe buffer limits on large scenes.
-    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
-        f.write(scene_json)
-        input_path = f.name
+    def _build(self) -> None:
+        subprocess.run(
+            ["bun", "run", str(_BUILD_TEST)],
+            check=True,
+            cwd=str(_JS_ROOT),
+            stderr=subprocess.PIPE,
+        )
 
-    out_path = input_path + ".out"
-    try:
-        args = [
-            "bun",
-            "run",
-            "--preload",
-            str(_PRELOAD),
-            "--conditions",
-            "source",
-            str(_CLI),
-            input_path,
-        ]
-        with open(out_path, "w") as outf:
-            proc = subprocess.run(
-                args, stdout=outf, stderr=subprocess.PIPE, text=True, cwd=str(_JS_ROOT)
-            )
-        with open(out_path) as f:
-            raw = f.read()
-    finally:
-        os.unlink(input_path)
-        if os.path.exists(out_path):
-            os.unlink(out_path)
+    def _bun_args(self, input_path: str) -> list[str]:
+        if self._debug:
+            return [
+                "bun",
+                "run",
+                "--preload",
+                str(_PRELOAD),
+                "--conditions",
+                "source",
+                str(_CLI),
+                input_path,
+            ]
+        return ["bun", "run", str(_BUNDLE), input_path]
 
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(
-            f"CLI produced non-JSON output (exit {proc.returncode}):\n{raw[:500]}\n{proc.stderr}"
-        ) from exc
-    return JSResult._from_json(data)
+    def check_data(self, scene_data: str | dict[str, Any]) -> JSResult:
+        """Validate pre-serialized scene data through the JS headless runner."""
+        scene_json = (
+            json.dumps(scene_data) if isinstance(scene_data, dict) else scene_data
+        )
 
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            f.write(scene_json)
+            input_path = f.name
 
-def check(scene_cls: type, fps: int = 10) -> JSResult:
-    """Instantiate scene_cls and validate it through the JS headless runner.
+        out_path = input_path + ".out"
+        try:
+            with open(out_path, "w") as outf:
+                proc = subprocess.run(
+                    self._bun_args(input_path),
+                    stdout=outf,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    cwd=str(_JS_ROOT),
+                )
+            with open(out_path) as f:
+                raw = f.read()
+        finally:
+            os.unlink(input_path)
+            if os.path.exists(out_path):
+                os.unlink(out_path)
 
-    Args:
-        scene_cls: A ManimWidget subclass.
-        fps: Frames per second for serialization.
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"CLI produced non-JSON output (exit {proc.returncode}):\n{raw[:500]}\n{proc.stderr}"
+            ) from exc
+        return JSResult._from_json(data)
 
-    Returns:
-        JSResult with errors, warnings, section_ids, and section_end_states.
-    """
-    scene = scene_cls(fps=fps)
-    return check_data(scene.scene_data)
+    def check_data_validated(
+        self, scene_data: str | dict[str, Any], schema: dict
+    ) -> JSResult:
+        """Validate against spec.json schema, then run through the JS headless runner."""
+        from jsonschema import validate
+
+        data = json.loads(scene_data) if isinstance(scene_data, str) else scene_data
+        validate(data, schema)
+        return self.check_data(data)
+
+    def check(self, scene_cls: type, fps: int = 10) -> JSResult:
+        """Instantiate scene_cls and validate it through the JS headless runner."""
+        scene = scene_cls(fps=fps)
+        return self.check_data(scene.scene_data)
 
 
 def _pretty_print(result: JSResult) -> None:
@@ -194,10 +242,10 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    runner = JSRunner(debug=True)
 
     if args.json:
-        scene_json = sys.stdin.read()
-        result = check_data(scene_json)
+        result = runner.check_data(sys.stdin.read())
     else:
         if not args.class_name:
             parser.error("class_name is required when providing an example file")
@@ -205,7 +253,7 @@ if __name__ == "__main__":
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         scene_cls = getattr(mod, args.class_name)
-        result = check(scene_cls)
+        result = runner.check(scene_cls)
 
     _pretty_print(result)
     sys.exit(0 if result.ok else 1)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+
+
+def _import(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _examples():
+    return sorted(_EXAMPLES_DIR.glob("*.py"))
+
+
+@pytest.mark.parametrize("path", _examples(), ids=lambda p: p.stem)
+def test_example(runner, path):
+    try:
+        mod = _import(path)
+    except Exception as e:
+        pytest.skip(f"import error: {e}")
+
+    test_fn = getattr(mod, "test", None)
+    if test_fn is None:
+        pytest.fail(
+            f"examples/{path.name} has no test(runner) function.\n"
+            f"Add one to opt in, or to explicitly opt out:\n\n"
+            f"    def test(runner):\n"
+            f"        pytest.skip('reason')"
+        )
+
+    test_fn(runner)

--- a/tests/test_js_integration.py
+++ b/tests/test_js_integration.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from jsonschema import validate
 
-from js_runner import check_data
 from manim import (
     BLUE,
     GREEN,
@@ -18,27 +17,19 @@ from manim import (
     RIGHT,
     UP,
     AnimationGroup,
-    Arrow,
     Circle,
     Create,
     Difference,
-    Dot,
     Ellipse,
     Exclusion,
-    GrowFromCenter,
     Intersection,
     ImageMobject,
-    Line,
     MarkupText,
-    MoveAlongPath,
-    Rotating,
     Square,
     Text,
-    Transform,
     Triangle,
     VGroup,
     VMobject,
-    linear,
     FadeIn,
 )
 from manim_widget.widget import ManimWidget
@@ -55,12 +46,6 @@ _SCHEMA = _load_schema()
 
 def assert_valid_schema(data: dict) -> None:
     validate(data, _SCHEMA)
-
-
-def check_data_validated(data):
-    """Like check_data but also validates against spec.json first."""
-    assert_valid_schema(data)
-    return check_data(data)
 
 
 def _create_logo_group() -> VGroup:
@@ -187,18 +172,6 @@ class TestCLIIntegration:
         return scene.scene_data
 
     @pytest.fixture
-    def arrow_with_tip_data(self) -> str:
-        class VectorArrow(ManimWidget):
-            def construct(self):
-                arrow = Arrow(
-                    ORIGIN, [1, 1, 0], buff=0, fill_opacity=1, stroke_opacity=1
-                )
-                self.add(arrow)
-
-        scene = VectorArrow()
-        return scene.scene_data
-
-    @pytest.fixture
     def vgroup_scale_section_data(self) -> str:
         class VGroupScaleSection(ManimWidget):
             def construct(self):
@@ -273,15 +246,15 @@ class TestCLIIntegration:
         scene = BooleanOperations()
         return scene.scene_data
 
-    def test_simple_scene(self, simple_scene_data):
-        r = check_data_validated(simple_scene_data)
+    def test_simple_scene(self, runner, simple_scene_data):
+        r = runner.check_data_validated(simple_scene_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 1
         assert sections[0]["name"] == "initial"
         assert len(sections[0]["ids"]) == 1
 
-    def test_fadein_image(self, fadein_image_data):
+    def test_fadein_image(self, runner, fadein_image_data):
         section = fadein_image_data["sections"][0]
         states = fadein_image_data["states"]
         # DAG: content entry (kind+source) is at index 0, addon entry (from+points) at index 1
@@ -298,13 +271,13 @@ class TestCLIIntegration:
         assert animate_cmd["animations"][0]["kind"] == "FadeIn"
         assert animate_cmd["animations"][0]["id"] == register_cmd["id"]
 
-        r = check_data_validated(fadein_image_data)
+        r = runner.check_data_validated(fadein_image_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 1
         assert len(sections[0]["ids"]) == 1
 
-    def test_animate_shift_left(self, animate_shift_left_data):
+    def test_animate_shift_left(self, runner, animate_shift_left_data):
         section = animate_shift_left_data["sections"][0]
         animate_cmds = [cmd for cmd in section["construct"] if cmd["cmd"] == "animate"]
         assert len(animate_cmds) == 2
@@ -312,14 +285,14 @@ class TestCLIIntegration:
         # not need injected Add.
         assert not any(a["kind"] == "Add" for a in animate_cmds[1]["animations"])
 
-        r = check_data_validated(animate_shift_left_data)
+        r = runner.check_data_validated(animate_shift_left_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 1
         assert len(sections[0]["ids"]) == 1
 
-    def test_multi_section_scene(self, multi_section_data):
-        r = check_data_validated(multi_section_data)
+    def test_multi_section_scene(self, runner, multi_section_data):
+        r = runner.check_data_validated(multi_section_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 2
@@ -328,36 +301,36 @@ class TestCLIIntegration:
         assert len(sections[0]["ids"]) == 1
         assert len(sections[1]["ids"]) == 2
 
-    def test_create_vgroup(self, vgroup_create_data):
-        r = check_data_validated(vgroup_create_data)
+    def test_create_vgroup(self, runner, vgroup_create_data):
+        r = runner.check_data_validated(vgroup_create_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         assert len(r.section_ids) == 1
 
-    def test_vgroup_reordered(self, vgroup_reordered_data):
-        r = check_data_validated(vgroup_reordered_data)
+    def test_vgroup_reordered(self, runner, vgroup_reordered_data):
+        r = runner.check_data_validated(vgroup_reordered_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         assert len(r.section_ids) == 1
 
-    def test_vgroup_scale_section(self, vgroup_scale_section_data):
-        r = check_data_validated(vgroup_scale_section_data)
+    def test_vgroup_scale_section(self, runner, vgroup_scale_section_data):
+        r = runner.check_data_validated(vgroup_scale_section_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 2
         assert sections[0]["name"] == "initial"
         assert sections[1]["name"] == "scale"
 
-    def test_vgroup_shift(self, vgroup_shift_data):
-        r = check_data_validated(vgroup_shift_data)
+    def test_vgroup_shift(self, runner, vgroup_shift_data):
+        r = runner.check_data_validated(vgroup_shift_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         assert len(r.section_ids) == 1
 
-    def test_boolean_operations(self, boolean_operations_data):
-        r = check_data_validated(boolean_operations_data)
+    def test_boolean_operations(self, runner, boolean_operations_data):
+        r = runner.check_data_validated(boolean_operations_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 1
 
-    def test_multi_subpath(self, multi_subpath_data):
+    def test_multi_subpath(self, runner, multi_subpath_data):
         vmob = VMobject()
         vmob.start_new_path(np.array([0, 0, 0]))
         vmob.add_line_to(np.array([1, 0, 0]))
@@ -370,21 +343,13 @@ class TestCLIIntegration:
             f"VMobject should have 2 subpaths, got {len(subpaths)}"
         )
 
-        r = check_data_validated(multi_subpath_data)
+        r = runner.check_data_validated(multi_subpath_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 1
         assert len(sections[0]["ids"]) == 1
 
-    def test_arrow_with_tip(self, arrow_with_tip_data):
-        r = check_data_validated(arrow_with_tip_data)
-        assert r.ok, f"CLI failed: {r.errors}"
-        assert r.error_count == 0, f"Expected no errors, got: {r.errors}"
-        sections = r.section_ids
-        assert len(sections) == 1
-        assert len(sections[0]["ids"]) >= 1
-
-    def test_invalid_contours_raises_error(self):
+    def test_invalid_contours_raises_error(self, runner):
         # contour with 9 points is invalid: must be 3n+1 (e.g. 4, 7, 10...)
         invalid_scene_data = {
             "version": 2,
@@ -416,46 +381,18 @@ class TestCLIIntegration:
             ],
         }
 
-        r = check_data(invalid_scene_data)
+        r = runner.check_data(invalid_scene_data)
         assert not r.ok, "Expected CLI to fail for invalid contour point count"
         assert any("3n+1" in str(e) for e in r.errors), (
             f"Expected 3n+1 error, got: {r.errors}"
         )
 
-    def test_boolean_operation(self, bool_operations_data):
-        r = check_data_validated(bool_operations_data)
+    def test_boolean_operation(self, runner, bool_operations_data):
+        r = runner.check_data_validated(bool_operations_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 1
         assert len(sections[0]["ids"]) >= 3
-
-    @pytest.fixture
-    def point_moving_on_shapes_data(self) -> str:
-        class PointMovingOnShapes(ManimWidget):
-            def construct(self):
-                circle = Circle(radius=1, color=BLUE)
-                dot = Dot()
-                dot2 = dot.copy().shift(RIGHT)
-                self.add(dot)
-
-                line = Line([3, 0, 0], [5, 0, 0])
-                self.add(line)
-
-                self.play(GrowFromCenter(circle))
-                self.play(Transform(dot, dot2))
-                self.play(MoveAlongPath(dot, circle), run_time=2, rate_func=linear)
-                self.play(Rotating(dot, about_point=[2, 0, 0]), run_time=1.5)
-                self.wait()
-
-        scene = PointMovingOnShapes()
-        return scene.scene_data
-
-    def test_point_moving_on_shapes(self, point_moving_on_shapes_data):
-        r = check_data_validated(point_moving_on_shapes_data)
-        sections = r.section_ids
-        assert r.ok, f"CLI failed: {r.errors}"
-        assert len(sections) == 1
-        assert sections[0]["name"] == "initial"
 
     @pytest.fixture
     def stroke_color_scene_data(self) -> str:
@@ -467,8 +404,8 @@ class TestCLIIntegration:
         scene = StrokeColorScene()
         return scene.scene_data
 
-    def test_cli_outputs_end_state_with_stroke(self, stroke_color_scene_data):
-        r = check_data_validated(stroke_color_scene_data)
+    def test_cli_outputs_end_state_with_stroke(self, runner, stroke_color_scene_data):
+        r = runner.check_data_validated(stroke_color_scene_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
 
         sections = r.section_end_states
@@ -496,8 +433,8 @@ class TestCLIIntegration:
         scene = GroupTwoObjectsScene()
         return scene.scene_data
 
-    def test_group_two_objects(self, group_two_objects_data):
-        r = check_data_validated(group_two_objects_data)
+    def test_group_two_objects(self, runner, group_two_objects_data):
+        r = runner.check_data_validated(group_two_objects_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         data = group_two_objects_data
         states = data["states"]
@@ -542,39 +479,16 @@ class TestCLIIntegration:
         scene = SwapScene()
         return scene.scene_data
 
-    def test_swap_animation(self, swap_animation_data):
-        r = check_data_validated(swap_animation_data)
+    def test_swap_animation(self, runner, swap_animation_data):
+        r = runner.check_data_validated(swap_animation_data, _SCHEMA)
         assert r.ok, f"CLI failed: {r.errors}"
         sections = r.section_ids
         assert len(sections) == 1
         # After swap, both original objects should be in the scene
         assert len(sections[0]["ids"]) == 2
 
-    @pytest.fixture
-    def cyclic_replace_animation_data(self) -> str:
-        from manim import CyclicReplace, Triangle, UP
 
-        class CyclicReplaceScene(ManimWidget):
-            def construct(self):
-                s1 = Square().shift(LEFT)
-                s2 = Circle().shift(RIGHT)
-                s3 = Triangle().shift(UP)
-                self.play(Create(s1), Create(s2), Create(s3))
-                self.play(CyclicReplace(s1, s2, s3))
-
-        scene = CyclicReplaceScene()
-        return scene.scene_data
-
-    def test_cyclic_replace_animation(self, cyclic_replace_animation_data):
-        r = check_data_validated(cyclic_replace_animation_data)
-        assert r.ok, f"CLI failed: {r.errors}"
-        sections = r.section_ids
-        assert len(sections) == 1
-        # After cyclic replace, all three objects should still be in the scene
-        assert len(sections[0]["ids"]) == 3
-
-
-def test_swap_with_world_coordinate_points():
+def test_swap_with_world_coordinate_points(runner):
     """
     Test that Swap works correctly with world-coordinate points.
 
@@ -686,7 +600,7 @@ def test_swap_with_world_coordinate_points():
         ],
     }
 
-    r = check_data_validated(scene_data)
+    r = runner.check_data_validated(scene_data, _SCHEMA)
     assert r.ok, f"CLI failed: {r.errors}"
 
     # After swap, circle 0 should be at x=+1, circle 1 at x=-1
@@ -707,7 +621,7 @@ def test_swap_with_world_coordinate_points():
     )
 
 
-def test_js_create_without_explicit_add_has_no_injected_add():
+def test_js_create_without_explicit_add_has_no_injected_add(runner):
     class CreateOnlyScene(ManimWidget):
         def construct(self):
             c = Circle()
@@ -721,33 +635,11 @@ def test_js_create_without_explicit_add_has_no_injected_add():
     assert not any(a["kind"] == "Add" for a in animate_cmd["animations"])
     assert any(a["kind"] == "Create" for a in animate_cmd["animations"])
 
-    r = check_data_validated(data)
+    r = runner.check_data_validated(data, _SCHEMA)
     assert r.ok, f"CLI failed: {r.errors}"
 
 
-def test_arrow_serialized_as_vgroup_with_shaft_and_tip():
-    """Arrow serializes as VGroup with 2 children: shaft (VMobject) + tip."""
-
-    class ArrowScene(ManimWidget):
-        def construct(self):
-            self.add(Arrow(ORIGIN, RIGHT))
-
-    scene = ArrowScene()
-    r = check_data_validated(scene.scene_data)
-    assert r.ok, f"CLI failed: {r.errors}"
-
-    states = r.section_end_states[0]["end_state"]["states"]
-    snapshot = r.section_end_states[0]["end_state"]["snapshot"]
-    root_ref = next(iter(snapshot.values()))
-    root_state = states[root_ref]
-
-    assert root_state["kind"] == "VGroup", f"Expected VGroup, got {root_state['kind']}"
-    assert len(root_state["children"]) == 2, (
-        f"Expected 2 children (shaft + tip), got {len(root_state['children'])}"
-    )
-
-
-def test_animation_group_plays_without_error():
+def test_animation_group_plays_without_error(runner):
     """AnimationGroup serializes start/end timestamps and plays back cleanly."""
 
     class AnimGroupScene(ManimWidget):
@@ -762,43 +654,7 @@ def test_animation_group_plays_without_error():
             )
 
     scene = AnimGroupScene()
-    r = check_data_validated(scene.scene_data)
+    r = runner.check_data_validated(scene.scene_data, _SCHEMA)
     assert r.ok, f"CLI failed:\n{r.errors}\n{r.section_ids}"
 
     assert r.error_count == 0
-
-
-def test_updater_mobs_are_in_scene():
-    """Regression: mobs registered via updater path must appear in scene, not just registry."""
-
-    class PointWithTrace(ManimWidget):
-        def construct(self):
-            path = VMobject()
-            dot = Dot()
-            path.set_points_as_corners([dot.get_center(), dot.get_center()])
-
-            def update_path(p):
-                prev = p.copy()
-                prev.add_points_as_corners([dot.get_center()])
-                p.become(prev)
-
-            path.add_updater(update_path)
-            self.add(path, dot)
-            self.play(Rotating(dot, angle=3.14, about_point=RIGHT, run_time=1))
-
-    scene = PointWithTrace(fps=5)
-    r = check_data_validated(scene.scene_data)
-    assert r.ok
-
-    section = scene.scene_data["sections"][0]
-    frame_ids = {
-        mob_id
-        for cmd in section["construct"]
-        if cmd["cmd"] == "updater"
-        for frame in cmd["frames"]
-        for mob_id in frame
-    }
-    scene_ids = set(r.scene_ids(0))
-    assert frame_ids <= scene_ids, (
-        f"Updater frame IDs not in scene: {frame_ids - scene_ids}"
-    )

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -825,25 +825,6 @@ def test_mathtex_boundary_points_and_scale_center():
         assert np.allclose(pt, [e * 0.5 for e in exp])
 
 
-def test_patch_tex_replaces_manim_classes():
-    from manim_widget import patch_tex
-    import manim
-
-    original_math_tex = manim.MathTex
-    original_tex = manim.Tex
-
-    patch_tex()
-
-    assert manim.MathTex is not original_math_tex
-    assert manim.Tex is not original_tex
-
-    tex = manim.Tex("test")
-    assert tex.tex_string == "test"
-
-    manim.MathTex = original_math_tex
-    manim.Tex = original_tex
-
-
 def test_patch_tex_mathtex_add_serializes_as_mathtexsource():
     from manim_widget import patch_tex
     import manim


### PR DESCRIPTION
## Summary

- Refactor js_runner.py into JSRunner class that pre-builds test_cli.js with typia baked in once per session (node_modules/.cache/manim-widget-test/) instead of invoking typia per test; cuts suite from ~2-3 min to ~1 min
- Add MANIM_WIDGET_JS_DEBUG=1 env var to skip bundle and run against TS source
- Move session-scoped runner fixture to tests/conftest.py (shared across files)
- Add tests/test_examples.py: parametrizes all examples, fails if no test()
- Add test(runner) to all examples; skip for LaTeX-dependent ones
- Fix instanceof VGroup check in test_cli.js (constructor.name mangled in bundle)
- Split CI into parallel integration and examples jobs

## Checklist

- [x] Ruff passes: `uvx ruff check . && uvx ruff format --check .`
- [x] Python tests pass: `uv run pytest -q tests/test_widget.py`
- [x] JS integration tests pass: `uv run pytest -q tests/test_js_integration.py`
- [x] If JS source changed: bundle rebuilt (`cd js && bun run build`)
- [x] If the emitted `scene_data` JSON changed shape: `spec.json` reflects the new shape and was updated before the code

## scene_data / spec changes

<!-- Delete this section if the emitted JSON is unchanged. Otherwise describe new or modified fields. -->

## Testing notes

<!-- Anything reviewers should know about how to verify this. -->
