### PR TITLE
fix(tex_patch): make patch_tex idempotent

### DIFF
--- a/src/manim_widget/__init__.py
+++ b/src/manim_widget/__init__.py
@@ -1,4 +1,4 @@
 from .widget import ManimWidget
-from .tex_patch import patch_tex
+from .tex_patch import patch_tex, unpatch_tex
 
-__all__ = ["ManimWidget", "patch_tex"]
+__all__ = ["ManimWidget", "patch_tex", "unpatch_tex"]

--- a/src/manim_widget/tex_patch.py
+++ b/src/manim_widget/tex_patch.py
@@ -93,8 +93,10 @@ def _patched_brace_get_tex(self, *tex, **kwargs):
 def patch_tex():
     import manim
 
-    _original_classes["MathTex"] = manim.MathTex
-    _original_classes["Tex"] = manim.Tex
+    if manim.MathTex is not PatchedMathTex:
+        _original_classes["MathTex"] = manim.MathTex
+    if manim.Tex is not PatchedTex:
+        _original_classes["Tex"] = manim.Tex
     manim.MathTex = PatchedMathTex
     manim.Tex = PatchedTex
 
@@ -102,3 +104,12 @@ def patch_tex():
 
     Brace.get_text = _patched_brace_get_text
     Brace.get_tex = _patched_brace_get_tex
+
+
+def unpatch_tex():
+    import manim
+
+    if "MathTex" in _original_classes:
+        manim.MathTex = _original_classes["MathTex"]
+    if "Tex" in _original_classes:
+        manim.Tex = _original_classes["Tex"]

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -667,13 +667,12 @@ def test_create_without_explicit_add_does_not_emit_add_animation():
 
 def test_mathtex_add_only_emits_add_animation():
     from manim_widget import patch_tex
+    from manim_widget.tex_patch import PatchedMathTex, unpatch_tex
     import manim
-
-    original_math_tex = manim.MathTex
-    original_tex = manim.Tex
 
     patch_tex()
     try:
+        assert manim.MathTex is PatchedMathTex
         from manim import MathTex, WHITE
 
         class MathTexAddOnlyScene(ManimWidget):
@@ -689,8 +688,7 @@ def test_mathtex_add_only_emits_add_animation():
             a["kind"] == "Add" and a["id"] == "0" for a in anim_cmd["animations"]
         )
     finally:
-        manim.MathTex = original_math_tex
-        manim.Tex = original_tex
+        unpatch_tex()
 
 
 def test_image_mobject_serializes_source_and_pixels():
@@ -827,13 +825,12 @@ def test_mathtex_boundary_points_and_scale_center():
 
 def test_patch_tex_mathtex_add_serializes_as_mathtexsource():
     from manim_widget import patch_tex
+    from manim_widget.tex_patch import PatchedMathTex, unpatch_tex
     import manim
-
-    original_math_tex = manim.MathTex
-    original_tex = manim.Tex
 
     patch_tex()
     try:
+        assert manim.MathTex is PatchedMathTex
         from manim import MathTex, WHITE
 
         class MathTexScene(ManimWidget):
@@ -854,8 +851,7 @@ def test_patch_tex_mathtex_add_serializes_as_mathtexsource():
         assert "points" in state
         assert len(state["points"]) == 4
     finally:
-        manim.MathTex = original_math_tex
-        manim.Tex = original_tex
+        unpatch_tex()
 
 
 def test_swap_animation_emits_group_animation():


### PR DESCRIPTION
patch_tex() no longer overwrites _original_classes when already patched, so calling it twice in a session still restores to the real originals. unpatch_tex() uses those stored originals, replacing the local-snapshot teardown pattern in tests that caused flakiness depending on test order.

Closes #53

