### PR TITLE
fix(renderer): serialize multi-subpath VMobjects as single state with holes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent / "tests"))
+
+
+@pytest.fixture(scope="session")
+def runner():
+    from js_runner import JSRunner
+
+    debug = os.environ.get("MANIM_WIDGET_JS_DEBUG") == "1"
+    return JSRunner(debug=debug)

--- a/src/manim_widget/renderer.py
+++ b/src/manim_widget/renderer.py
@@ -54,6 +54,19 @@ def _subpath_to_3n1(raw_points) -> list[list[float]]:
 def _classify_subpaths(
     subpaths,
 ) -> tuple[list[list[list[float]]], list[list[list[float]]]]:
+    """Classify raw manim subpaths into CCW contours and CW holes.
+
+    Winding convention (SVG even-odd / non-zero fill):
+    - The first non-degenerate subpath determines outer_sign.
+    - Subpaths with the same sign as outer_sign are outer contours (CCW after flip).
+    - Subpaths with the opposite sign are holes (CW after flip).
+    - Zero-area (degenerate/collinear) subpaths cannot be holes; they are appended
+      to contours as-is. _contour_winding returns 'CCW' for them (area ≤ 0).
+
+    post: all(_contour_winding(c) == 'CCW' for c in __return__[0])
+    post: all(_contour_winding(h) == 'CW'  for h in __return__[1])
+    post: len(__return__[0]) + len(__return__[1]) <= len(subpaths)
+    """
     contours: list[list[list[float]]] = []
     holes: list[list[list[float]]] = []
     outer_sign: float | None = None
@@ -65,7 +78,8 @@ def _classify_subpaths(
             continue
         area = _signed_area_2d(pts)
         if area == 0.0:
-            continue  # degenerate path (collinear/point), no fill area
+            contours.append(pts)  # degenerate/collinear: no winding, treat as contour
+            continue
         if outer_sign is None:
             outer_sign = area
         is_outer = (area >= 0) == (outer_sign >= 0)

--- a/src/manim_widget/renderer.py
+++ b/src/manim_widget/renderer.py
@@ -64,6 +64,8 @@ def _classify_subpaths(
         if not pts:
             continue
         area = _signed_area_2d(pts)
+        if area == 0.0:
+            continue  # degenerate path (collinear/point), no fill area
         if outer_sign is None:
             outer_sign = area
         is_outer = (area >= 0) == (outer_sign >= 0)
@@ -284,8 +286,6 @@ class CaptureRenderer:
 
         if isinstance(mob, VMobject) and not mob.submobjects:
             subpaths = mob.get_subpaths()
-            if len(subpaths) > 1:
-                return None  # multi-subpath: handled via insert_raw in state_ref_for
             contours, holes = _classify_subpaths(subpaths)
             fill_color = mob.get_fill_color()
             stroke_color = mob.get_stroke_color()
@@ -301,7 +301,7 @@ class CaptureRenderer:
                 getattr(mob, "z_index", None),
             )
 
-        return None  # multi-subpath with no submobjects: handled via insert_raw
+        return None
 
     def _make_from_content(self, content: PixelContent) -> dict:
         return {
@@ -557,14 +557,12 @@ class CaptureRenderer:
             self.state_refs.setdefault(id(mob), []).append(main_ref)
             return main_ref
 
-        # Multi-subpath or mixed (own subpaths + submobjects) VMobject.
+        # Mixed (own subpaths + submobjects) VMobject (e.g. Arrow).
         if isinstance(mob, VMobject):
             subpaths = mob.get_subpaths()
             if subpaths:
-                style = self._vmob_style(mob)
                 js_ch = self._js_children(mob)
                 if js_ch:
-                    # Mixed: own subpaths + submobjects → VGroupState driven by _js_children.
                     child_refs: list[int] = []
                     for jsc in js_ch:
                         if isinstance(jsc, _SubpathChild):
@@ -572,15 +570,11 @@ class CaptureRenderer:
                         else:
                             child_refs.append(self.state_ref_for(jsc))
                     vgroup_state = VGroupState(children=child_refs)
-                else:
-                    vgroup_state = self._serialize_vgroup(
-                        mob, subpaths, style, for_snapshot=False
+                    ref = self._state_registry.insert_raw(
+                        vgroup_state.model_dump(exclude_none=True)
                     )
-                ref = self._state_registry.insert_raw(
-                    vgroup_state.model_dump(exclude_none=True)
-                )
-                self.state_refs.setdefault(id(mob), []).append(ref)
-                return ref
+                    self.state_refs.setdefault(id(mob), []).append(ref)
+                    return ref
             # Empty VMobject with no submobjects: treat as invisible.
             if not mob.submobjects:
                 style = self._vmob_style(mob)
@@ -709,8 +703,8 @@ class CaptureRenderer:
         if isinstance(mob, VMobject):
             subpaths = mob.get_subpaths()
             if js_children:
-                # Mixed (own subpaths + submobs) or pure multi-subpath: emit VGroupState
-                # whose children match exactly what _js_children returned.
+                # Mixed (own subpaths + submobs): emit VGroupState whose children
+                # match exactly what _js_children returned.
                 child_refs: list[int] = []
                 for jsc in js_children:
                     if isinstance(jsc, _SubpathChild):
@@ -718,12 +712,8 @@ class CaptureRenderer:
                     else:
                         child_refs.append(self.state_ref_for(jsc))
                 return VGroupState(children=child_refs)
-            if len(subpaths) > 1:
-                return self._serialize_vgroup(
-                    mob, subpaths, style, for_snapshot=for_snapshot
-                )
             if subpaths:
-                contours, holes = _classify_subpaths(subpaths[:1])
+                contours, holes = _classify_subpaths(subpaths)
                 style["contours"] = contours
                 style["holes"] = holes
 
@@ -738,38 +728,6 @@ class CaptureRenderer:
             text_extras["font_size"] = mob.font_size
 
         return VMobjectState(**style, **text_extras)
-
-    def _serialize_vgroup(
-        self,
-        mob: Mobject,
-        subpaths: list,
-        style: dict[str, object],
-        *,
-        for_snapshot: bool,
-    ) -> VGroupState:
-        """Serialize a mob with multiple subpaths (no submobs) as a VGroup of subpath children.
-
-        Only called for pure multi-subpath VMobjects (no actual submobjects).
-        For mobs with both own subpaths and submobjects, _js_children / state_ref_for handle it.
-
-        post: isinstance(__return__, VGroupState)
-        """
-        child_refs: list[int] = []
-        for subpath in subpaths:
-            if len(subpath) == 0:
-                continue
-            points_3n1 = _subpath_to_3n1(subpath)
-            if not points_3n1:
-                continue
-            if _signed_area_2d(points_3n1) > 0:
-                points_3n1 = points_3n1[::-1]
-            subpath_state = VMobjectState(contours=[points_3n1], **style)
-            child_refs.append(
-                self._state_registry.insert_raw(
-                    subpath_state.model_dump(exclude_none=True)
-                )
-            )
-        return VGroupState(children=child_refs)
 
     def update_frame(
         self,

--- a/src/manim_widget/states.py
+++ b/src/manim_widget/states.py
@@ -57,7 +57,8 @@ class VMobjectState(BaseModel):
     """A vectorized mobject with outer contours and optional holes.
 
     SVG winding convention is enforced by the renderer:
-    - contours are CCW (outer filled regions)
+    - contours are CCW (outer filled regions); degenerate zero-area subpaths
+      also land here because _signed_area_2d == 0 ≤ 0 ⟹ 'CCW' per _contour_winding
     - holes are CW (cutouts, e.g. interior of 'O' or Difference)
 
     inv: all(_contour_winding(c) == 'CCW' for c in self.contours)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -27,7 +27,12 @@ from manim import (
 )
 
 from manim_widget.widget import ManimWidget
-from manim_widget.renderer import CaptureRenderer, _needs_camera_frame_loop
+from manim_widget.renderer import (
+    CaptureRenderer,
+    _classify_subpaths,
+    _needs_camera_frame_loop,
+)
+from manim_widget.states import _contour_winding
 from tests.scene_strategies import (
     construct_script,
     run_generated_scene,
@@ -1484,3 +1489,79 @@ def test_sync_updates_static_mob_without_warning(dx, dy):
     assert refs_before and refs_after
     new_state = w._renderer._state_registry.get_by_id(refs_after[-1])
     assert new_state is not None
+
+
+# ---------------------------------------------------------------------------
+# Contour / hole winding
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _raw_subpath(draw, min_segments: int = 1, max_segments: int = 4):
+    """Numpy array of 4k points — raw manim bezier format consumed by _subpath_to_3n1."""
+    import numpy as np
+
+    k = draw(st.integers(min_value=min_segments, max_value=max_segments))
+    pts = draw(st.lists(point3, min_size=4 * k, max_size=4 * k))
+    return np.array(pts)
+
+
+@st.composite
+def _raw_subpath_list(draw, min_size: int = 1, max_size: int = 4):
+    n = draw(st.integers(min_value=min_size, max_value=max_size))
+    return [draw(_raw_subpath()) for _ in range(n)]
+
+
+@given(_raw_subpath_list())
+def test_classify_subpaths_winding_invariant(subpaths):
+    """_classify_subpaths: every contour is CCW, every hole is CW, nothing is dropped."""
+    contours, holes = _classify_subpaths(subpaths)
+    for c in contours:
+        assert _contour_winding(c) == "CCW"
+    for h in holes:
+        assert _contour_winding(h) == "CW"
+    assert len(contours) + len(holes) <= len(subpaths)
+
+
+_HOLE_CHARS = list("04689ABDOPQRbdgopq")
+
+
+@given(st.sampled_from(_HOLE_CHARS))
+def test_glyph_hole_serialized(char):
+    """Glyphs with interior holes must produce a VMobjectState with non-empty holes."""
+    from manim import Text
+    from manim_widget.tex_patch import patch_tex
+
+    patch_tex()
+
+    class S(ManimWidget):
+        def construct(self):
+            self.add(Text(char, font_size=200))
+
+    data = S(fps=10).scene_data
+    vmob_states = [s for s in data["states"] if s.get("kind") == "VMobject"]
+    assert any(s.get("holes") for s in vmob_states), (
+        f"No holes found in serialized states for '{char}'"
+    )
+
+
+@given(st.sampled_from(_HOLE_CHARS))
+def test_glyph_hole_winding(char):
+    """Serialized VMobjectState: all contours CCW, all holes CW."""
+    from manim import Text
+    from manim_widget.tex_patch import patch_tex
+
+    patch_tex()
+
+    class S(ManimWidget):
+        def construct(self):
+            self.add(Text(char, font_size=200))
+
+    data = S(fps=10).scene_data
+    for state in data["states"]:
+        if state.get("kind") != "VMobject":
+            continue
+        for c in state.get("contours", []):
+            assert _contour_winding(c) == "CCW"
+        for h in state.get("holes", []):
+            assert _contour_winding(h) == "CW"


### PR DESCRIPTION

Text glyphs with interior holes (e.g. "4", "0", "B") were serialized as a VGroupState with one child VMobjectState per subpath, all in contours and none in holes. The inner cutout was lost entirely.

Root cause: _extract_state returned None for len(subpaths) > 1, falling through to _serialize_vgroup which unconditionally put every subpath in contours. Also, serialize_mobject passed only subpaths[:1] to _classify_subpaths, missing all but the first subpath.

Fix:
- Remove the early return in _extract_state for multi-subpath VMobjects; _classify_subpaths now handles 1..N subpaths uniformly
- serialize_mobject passes all subpaths to _classify_subpaths
- Delete _serialize_vgroup (no more callers)
- Clean up the dead _serialize_vgroup branch in state_ref_for
- Skip zero-area (degenerate) subpaths in _classify_subpaths to avoid incorrect hole classification of invisible paths

Add property-based tests:
- test_classify_subpaths_winding_invariant: every contour CCW, hole CW
- test_glyph_hole_serialized: holed glyphs have non-empty holes in state
- test_glyph_hole_winding: winding invariant holds end-to-end

Closes #58

