### PR TITLE
fix(camera): capture initial camera snapshot after construct() runs

### DIFF
--- a/examples/zy_cnn_parallelepipeds.py
+++ b/examples/zy_cnn_parallelepipeds.py
@@ -25,7 +25,7 @@ with app.setup:
     )
     from manim_widget import ManimWidget
 
-    _DEFAULT_IMAGE_URL = "https://storage.googleapis.com/kaggle-datasets-images/6175990/10028340/a0b959a027a7dd839dccfd847af56177/dataset-card.jpg"
+    DEFAULT_IMAGE_URL = "https://storage.googleapis.com/kaggle-datasets-images/6175990/10028340/a0b959a027a7dd839dccfd847af56177/dataset-card.jpg"
 
     def load_image_array(url: str) -> np.ndarray:
         with urlopen(url) as response:
@@ -92,12 +92,13 @@ with app.setup:
 
 @app.class_definition
 class ZYImageCNN(ManimWidget):
-    image_url: str = _DEFAULT_IMAGE_URL
+    image_url: str = DEFAULT_IMAGE_URL
 
     def construct(self):
-        self.camera.phi = 1.5
-        self.camera.theta = -0.8
-        self.camera.distance = 10
+        self.camera.set_phi(1.5)
+        self.camera.set_theta(-0.8)
+        self.camera.set_focal_distance(10)
+        self.camera.set_zoom(2)
 
         img = ImageMobject(load_image_array(self.image_url))
         img.height = 3.0

--- a/src/manim_widget/widget.py
+++ b/src/manim_widget/widget.py
@@ -78,6 +78,7 @@ class ManimWidget(anywidget.AnyWidget, ThreeDScene):
 
         self.construct()
 
+        self._patch_initial_camera_snapshot()
         self._renderer.flush_staged_adds()
         self._renderer.emit_final_add_animations(self)
 
@@ -89,6 +90,30 @@ class ManimWidget(anywidget.AnyWidget, ThreeDScene):
             frame_height=float(self.camera.frame_height),
         )
         self.scene_data = data
+
+    def _patch_initial_camera_snapshot(self) -> None:
+        """Re-serialize the camera into the first section's snapshot after construct() has run.
+
+        _flush_setup_to_section() is called before construct(), so any camera
+        mutations made at the start of construct() (set_phi, set_theta, etc.)
+        are not captured in the initial snapshot.  This method fixes that by
+        overwriting the #camera entry with the camera's state as it is now.
+        """
+        sections = self._renderer.sections
+        if not sections:
+            return
+        initial_setup = sections[0].setup
+        cam_entry = next((e for e in initial_setup if e.get("id") == "#camera"), None)
+        if cam_entry is None:
+            return
+        cam = self.camera
+        fw = float(getattr(cam, "frame_width", 14.222))
+        fh = float(getattr(cam, "frame_height", 8.0))
+        cam_pts, cam_focal = _serialize_camera(cam, fw, fh)
+        self._renderer._state_registry.overwrite(
+            cam_entry["state_ref"],
+            {"kind": "Camera", "points": cam_pts, "focal_distance": cam_focal},
+        )
 
     def _mob_is_animated(self, mob: Mobject) -> bool:
         """Return True if mob was the source or target of any animation during construction."""

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1506,6 +1506,48 @@ def test_glyph_hole_serialized(char):
     )
 
 
+@given(
+    phi=st.floats(0.1, 1.9, allow_nan=False, allow_infinity=False),
+    theta=st.floats(-2.5, 2.5, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=20, deadline=None)
+def test_initial_camera_snapshot_matches_construct_camera(phi, theta):
+    """The #camera in the first section's snapshot must reflect the camera configured
+    at the start of construct() via set_phi/set_theta, not the default camera serialized
+    at section-open time (before construct() runs)."""
+    from manim_widget._camera import _serialize_camera
+
+    class CameraScene(ManimWidget):
+        _phi = phi
+        _theta = theta
+
+        def construct(self):
+            self.camera.set_phi(self._phi)
+            self.camera.set_theta(self._theta)
+            self.play(Create(Circle()))
+
+    widget = CameraScene(is_3d=True)
+    data = widget.scene_data
+
+    section = data["sections"][0]
+    cam_ref = section["snapshot"]["#camera"]
+    snapshot_cam_state = data["states"][cam_ref]
+
+    cam = widget.camera
+    fw = float(cam.frame_width)
+    fh = float(cam.frame_height)
+    expected_pts, expected_focal = _serialize_camera(cam, fw, fh)
+
+    assert snapshot_cam_state["kind"] == "Camera"
+    assert np.allclose(snapshot_cam_state["points"], expected_pts, atol=1e-5), (
+        f"snapshot camera does not match construct() camera "
+        f"(phi={phi:.3f}, theta={theta:.3f})\n"
+        f"  snapshot: {snapshot_cam_state['points']}\n"
+        f"  expected: {expected_pts}"
+    )
+    assert abs(snapshot_cam_state["focal_distance"] - expected_focal) < 1e-5
+
+
 @given(st.sampled_from(_HOLE_CHARS))
 def test_glyph_hole_winding(char):
     """Serialized VMobjectState: all contours CCW, all holes CW."""


### PR DESCRIPTION
The initial section snapshot was serialized before construct() executed, so set_phi/set_theta/set_focal_distance calls at the start of construct() were silently ignored. Added _patch_initial_camera_snapshot() to overwrite the #camera state in-place after construction.

Also fixes the ZYImageCNN example to use the correct ThreeDCamera API (set_phi, set_theta, set_focal_distance, set_zoom) and adds a Hypothesis property test that catches this class of bug.