### PR TITLE
fix(example): correct top/bottom face rotation in cnn_block

### DIFF
--- a/examples/zy_cnn_parallelepipeds.py
+++ b/examples/zy_cnn_parallelepipeds.py
@@ -76,7 +76,7 @@ with app.setup:
             fill_opacity=0.45,
             **style,
         )
-        top.rotate(PI / 2, axis=UP)
+        top.rotate(PI / 2, axis=RIGHT)
         top.shift(UP * (y_size / 2))
         bottom = Rectangle(
             width=x_thickness,
@@ -85,7 +85,7 @@ with app.setup:
             fill_opacity=0.18,
             **style,
         )
-        bottom.rotate(PI / 2, axis=UP)
+        bottom.rotate(PI / 2, axis=RIGHT)
         bottom.shift(UP * (-y_size / 2))
         return VGroup(back, bottom, left_face, right_face, top, front)
 


### PR DESCRIPTION
top and bottom were rotated around UP (Y axis) which left them in the YZ plane instead of the XZ plane. Changed to axis=RIGHT so they lie flat as horizontal faces of the parallelepiped.

## Summary

<!-- What does this PR do and why? -->

## Checklist

- [ ] Ruff passes: `uvx ruff check . && uvx ruff format --check .`
- [ ] Python tests pass: `uv run pytest -q tests/test_widget.py`
- [ ] JS integration tests pass: `uv run pytest -q tests/test_js_integration.py`
- [ ] If JS source changed: bundle rebuilt (`cd js && bun run build`)
- [ ] If the emitted `scene_data` JSON changed shape: `spec.json` reflects the new shape and was updated before the code

## scene_data / spec changes

<!-- Delete this section if the emitted JSON is unchanged. Otherwise describe new or modified fields. -->

## Testing notes

<!-- Anything reviewers should know about how to verify this. -->
