### PR TITLE
feat(widget): warn when camera is animated on a 2D scene

### DIFF
--- a/src/manim_widget/widget.py
+++ b/src/manim_widget/widget.py
@@ -131,6 +131,30 @@ class ManimWidget(anywidget.AnyWidget, ThreeDScene):
             frame_height=float(self.camera.frame_height),
         )
 
+        if not is_3d:
+            self._warn_if_camera_animated()
+
+    def _warn_if_camera_animated(self) -> None:
+        import warnings
+
+        for section in self.data.sections:
+            for cmd in section.animate_commands():
+                if any(a.id == "#camera" for a in cmd.animations):
+                    warnings.warn(
+                        "Camera was animated in a 2D scene. "
+                        "Pass is_3d=True when creating the widget to enable 3D camera support.",
+                        stacklevel=4,
+                    )
+                    return
+            for cmd in section.updater_commands():
+                if any("#camera" in frame for frame in cmd.frames):
+                    warnings.warn(
+                        "Camera was animated in a 2D scene. "
+                        "Pass is_3d=True when creating the widget to enable 3D camera support.",
+                        stacklevel=4,
+                    )
+                    return
+
     def _patch_initial_camera_snapshot(self) -> None:
         """Re-serialize the camera into the first section's snapshot after construct() has run.
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -937,6 +937,39 @@ def test_camera_state_has_four_points_and_focal_distance():
     assert fd > 0
 
 
+def test_camera_animation_on_2d_scene_warns():
+    import warnings
+    from manim import PI
+
+    class CamScene(ManimWidget):
+        def construct(self):
+            self.move_camera(phi=PI / 4)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        CamScene()
+
+    msgs = [str(w.message) for w in caught if "is_3d" in str(w.message)]
+    assert len(msgs) == 1
+    assert "is_3d=True" in msgs[0]
+
+
+def test_camera_animation_on_3d_scene_does_not_warn():
+    import warnings
+    from manim import PI
+
+    class CamScene3D(ManimWidget):
+        def construct(self):
+            self.move_camera(phi=PI / 4)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        CamScene3D(is_3d=True)
+
+    msgs = [str(w.message) for w in caught if "is_3d" in str(w.message)]
+    assert len(msgs) == 0
+
+
 def test_same_square_scaled_and_readded_serializes_only_scaled_state():
     class ScaledSquareScene(ManimWidget):
         def construct(self):


### PR DESCRIPTION
Closes #69

## Summary

- After `construct()` runs, scans all sections for `#camera` entries in `animate` and `updater` commands
- If any are found and `is_3d=False`, emits a `UserWarning` suggesting `is_3d=True`
- No warning on 3D scenes or scenes without camera animation

## Test plan

- [ ] `test_camera_animation_on_2d_scene_warns` — warning fired with correct message
- [ ] `test_camera_animation_on_3d_scene_does_not_warn` — no warning when `is_3d=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)