### PR TITLE
fix(subpaths): don't reverse open paths in _classify_subpaths

### DIFF
--- a/src/manim_widget/_subpaths.py
+++ b/src/manim_widget/_subpaths.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .states import _signed_area_2d
+from .states import _is_open_contour, _signed_area_2d
 
 
 def _subpath_to_3n1(raw_points) -> list[list[float]]:
@@ -37,6 +37,9 @@ def _classify_subpaths(
             continue
         pts = _subpath_to_3n1(sp)
         if not pts:
+            continue
+        if _is_open_contour(pts):
+            contours.append(pts)  # open paths have no winding; preserve direction
             continue
         area = _signed_area_2d(pts)
         if area == 0.0:

--- a/src/manim_widget/states.py
+++ b/src/manim_widget/states.py
@@ -27,13 +27,28 @@ def _signed_area_2d(pts: Contour) -> float:
     )
 
 
+def _is_open_contour(pts: Contour) -> bool:
+    """Return True when the path does not close back on its start point.
+
+    Open paths (e.g. function graphs) have no meaningful winding direction;
+    the signed-area test should not be applied to them.
+    """
+    p0, p1 = pts[0], pts[-1]
+    return (p0[0] - p1[0]) ** 2 + (p0[1] - p1[1]) ** 2 > 1e-9
+
+
 def _contour_winding(pts: Contour) -> str:
     """Return 'CW' or 'CCW' for a 3n+1 contour.
+
+    Open paths (start ≠ end) have no winding direction and always return 'CCW'
+    so they pass through the fill-rule normalisation unchanged.
 
     pre: len(pts) > 0
     pre: (len(pts) - 1) % 3 == 0
     post: __return__ in ('CW', 'CCW')
     """
+    if _is_open_contour(pts):
+        return "CCW"
     return "CW" if _signed_area_2d(pts) > 0 else "CCW"
 
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -240,6 +240,42 @@ def test_value_tracker_state_round_trips_via_model_dump(state):
 
 
 # ---------------------------------------------------------------------------
+# Property tests: open-path winding and direction preservation
+# ---------------------------------------------------------------------------
+
+
+def _3n1_to_raw(pts):
+    """Convert a 3n+1 contour back to Manim's 4-point Bezier chunk format."""
+    import numpy as np
+
+    chunks = []
+    for i in range(0, len(pts) - 1, 3):
+        chunks.extend([pts[i], pts[i + 1], pts[i + 2], pts[i + 3]])
+    return np.array(chunks, dtype=float)
+
+
+@given(bezier_points_3n1(min_segments=1))
+def test_open_contour_winding_is_always_ccw(pts):
+    """∀ open contour: _contour_winding returns 'CCW' regardless of signed area."""
+    from manim_widget.states import _contour_winding, _is_open_contour
+
+    assume(_is_open_contour(pts))
+    assert _contour_winding(pts) == "CCW"
+
+
+@given(bezier_points_3n1(min_segments=1))
+def test_open_contour_direction_preserved_by_classify(pts):
+    """_classify_subpaths must not reverse an open contour."""
+    from manim_widget.states import _is_open_contour
+
+    assume(_is_open_contour(pts))
+    contours, holes = _classify_subpaths([_3n1_to_raw(pts)])
+    assert holes == []
+    assert len(contours) == 1
+    assert contours[0][0] == pts[0]
+
+
+# ---------------------------------------------------------------------------
 # Spec ↔ model structural alignment
 #
 # Two invariants for every (model type, spec definition) pair:


### PR DESCRIPTION
Closes #61

## Root cause

`_classify_subpaths` reversed subpath point arrays based on signed-area winding order. The guard `area == 0.0` only caught exact zeros — open paths (function graphs, line segments) have a small but non-zero signed area, so they slipped through and got reversed. This caused `MoveAlongPath` to animate right-to-left on a left-to-right curve.

## Fix

- Add `_is_open_contour(pts)` in `states.py`: checks whether first and last points differ by more than 1e-9 (squared distance)
- In `_classify_subpaths`: test for open contour before the area test; if open, append as-is
- `_contour_winding` returns `'CCW'` for open paths so the `VMobjectState` validator accepts them unchanged

## Test plan

- [ ] `uv run pytest tests/test_widget.py` — 80/80 passing
- Manual: `MoveAlongPath` on `ax.plot(sin, x_range=[0, 3π])` now moves left-to-right (first serialised x ≈ −4.9, matching `graph.get_points()[0]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)