### PR TITLE
Skip empty initial section

### DIFF
--- a/src/manim_widget/widget.py
+++ b/src/manim_widget/widget.py
@@ -49,6 +49,7 @@ def serialize_scene(
     frame_height: float = 8.0,
     background_color: str = "#000000",
 ) -> SceneData:
+    sections = _without_implicit_empty_initial_section(sections)
     section_data = [
         SectionData(
             name=s.name,
@@ -78,6 +79,19 @@ def serialize_scene(
 
     check_scene_data(scene)
     return scene
+
+
+def _without_implicit_empty_initial_section(
+    sections: list[SectionRecord],
+) -> list[SectionRecord]:
+    if len(sections) < 2:
+        return sections
+    first = sections[0]
+    if first.name != "initial" or first.commands:
+        return sections
+    if any(entry.id != "#camera" for entry in first.setup):
+        return sections
+    return sections[1:]
 
 
 class ManimWidget(anywidget.AnyWidget, ThreeDScene):

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -688,6 +688,37 @@ def test_multiple_sections_with_move_to_target():
         assert anim.kind == "MoveToTarget"
 
 
+def test_first_call_next_section_omits_empty_initial_section():
+    class StartsWithSection(ManimWidget):
+        def construct(self):
+            self.next_section("intro")
+            c = Circle()
+            self.play(Create(c))
+
+    scene = StartsWithSection()
+    data = scene.data
+    assert_valid_scene(data)
+
+    assert [s.name for s in data.sections] == ["intro"]
+    assert data.sections[0].snapshot.keys() == {"#camera"}
+    first_animate = data.sections[0].animate_commands()[0]
+    assert any(a.kind == "Create" for a in first_animate.animations)
+
+
+def test_non_empty_initial_section_is_preserved_before_next_section():
+    class InitialThenSection(ManimWidget):
+        def construct(self):
+            c = Circle()
+            self.play(Create(c))
+            self.next_section("after")
+
+    scene = InitialThenSection()
+    data = scene.data
+    assert_valid_scene(data)
+
+    assert [s.name for s in data.sections] == ["initial", "after"]
+
+
 def test_add_injected_for_explicit_add_before_non_introducer_animation():
     class ShiftScene(ManimWidget):
         def construct(self):

--- a/uv.lock
+++ b/uv.lock
@@ -846,7 +846,7 @@ wheels = [
 
 [[package]]
 name = "manim-widget"
-version = "0.1.6"
+version = "0.2.0rc0"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary
- omit the implicit empty initial section when construct starts with next_section()
- preserve non-empty initial sections
- keep uv.lock aligned with 0.2.0rc0

## Tests
- uv run pytest -q tests/test_widget.py::test_first_call_next_section_omits_empty_initial_section tests/test_widget.py::test_non_empty_initial_section_is_preserved_before_next_section