### PR TITLE
fix: read bundled JS with explicit utf-8 encoding

### DIFF
--- a/src/manim_widget/widget.py
+++ b/src/manim_widget/widget.py
@@ -30,7 +30,7 @@ def _camera_bg_hex(camera: Any) -> str:
     return str(bg)
 
 
-_JS_BUNDLE = _ESM.read_text()
+_JS_BUNDLE = _ESM.read_text(encoding="utf-8")
 
 
 def _scene_data_to_json(scene_data: SceneData, widget: anywidget.AnyWidget) -> dict:


### PR DESCRIPTION
## Summary
- `Path.read_text()` without an explicit encoding falls back to the platform's preferred encoding, which is `cp1252` on Windows.
- The bundled `static/index.js` is UTF-8 and can contain bytes that aren't valid `cp1252`, causing `UnicodeDecodeError` on import for Windows users.
- Pass `encoding="utf-8"` explicitly so the bundle is read correctly on all platforms.

Closes #81

## Test plan
- [x] `ruff`/pre-commit hooks pass
- [ ] Confirm import succeeds on Windows (reporter to verify)